### PR TITLE
ci: add CMS build script for Railway

### DIFF
--- a/apps/cms/.keystone/config.js
+++ b/apps/cms/.keystone/config.js
@@ -1,7 +1,9 @@
 "use strict";
+var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __export = (target, all) => {
   for (var name in all)
@@ -15,6 +17,14 @@ var __copyProps = (to, from, except, desc) => {
   }
   return to;
 };
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // keystone.ts
@@ -23,6 +33,7 @@ __export(keystone_exports, {
   default: () => keystone_default
 });
 module.exports = __toCommonJS(keystone_exports);
+var dotenv = __toESM(require("dotenv"));
 var import_core2 = require("@keystone-6/core");
 
 // schema.ts
@@ -169,6 +180,7 @@ var session = (0, import_session.statelessSessions)({
 });
 
 // keystone.ts
+dotenv.config();
 var keystone_default = withAuth(
   (0, import_core2.config)({
     db: {
@@ -176,7 +188,7 @@ var keystone_default = withAuth(
       //   for more information on what database might be appropriate for you
       //   see https://keystonejs.com/docs/guides/choosing-a-database#title
       provider: "postgresql",
-      url: process.env.CMS_DATABASE_URL ?? "mysql://root:dbpass@localhost:3306/find-a-project",
+      url: process.env.CMS_DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/find-a-project",
       prismaClientPath: "node_modules/.prisma/client"
     },
     server: {

--- a/apps/cms/.keystone/config.js
+++ b/apps/cms/.keystone/config.js
@@ -139,7 +139,7 @@ var lists = {
 var import_crypto = require("crypto");
 var import_auth = require("@keystone-6/auth");
 var import_session = require("@keystone-6/core/session");
-var sessionSecret = process.env.SESSION_SECRET;
+var sessionSecret = process.env.CMS_SESSION_SECRET;
 if (!sessionSecret && process.env.NODE_ENV !== "production") {
   sessionSecret = (0, import_crypto.randomBytes)(32).toString("hex");
 }

--- a/apps/cms/keystone.ts
+++ b/apps/cms/keystone.ts
@@ -22,7 +22,7 @@ export default withAuth(
       provider: "postgresql",
       url:
         process.env.CMS_DATABASE_URL ??
-        "mysql://root:dbpass@localhost:3306/find-a-project",
+        "postgresql://postgres:postgres@localhost:5432/find-a-project",
       prismaClientPath: "node_modules/.prisma/client",
     },
     server: {

--- a/apps/cms/keystone.ts
+++ b/apps/cms/keystone.ts
@@ -1,7 +1,10 @@
 // Welcome to Keystone!
 //
 // This file is what Keystone uses as the entry-point to your headless backend
-//
+
+import * as dotenv from "dotenv"; // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
+dotenv.config();
+
 // Keystone imports the default export of this file, expecting a Keystone configuration object
 //   you can find out more at https://keystonejs.com/docs/apis/config
 import { config } from "@keystone-6/core";

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -14,6 +14,7 @@
     "@keystone-6/core": "^5.0.0",
     "@keystone-6/fields-document": "^7.0.0",
     "@prisma/client": "^4.12.0",
+    "dotenv": "^16.0.3",
     "typescript": "^4.9.5"
   },
   "devDependencies": {

--- a/bin/cms/railway-build.sh
+++ b/bin/cms/railway-build.sh
@@ -2,4 +2,4 @@ pnpm build:cms
 pnpm deploy:cms
 
 # output environment variables to file
-cd apps/cms && env | grep CMS_SESSION_SECRET >> .env
+cd apps/cms && env | grep -e CMS_ >> .env

--- a/bin/cms/railway-build.sh
+++ b/bin/cms/railway-build.sh
@@ -1,0 +1,5 @@
+pnpm build:cms
+pnpm deploy:cms
+
+# output environment variables to file
+cd apps/cms && env | grep CMS_SESSION_SECRET >> .env

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@prisma/client':
         specifier: ^4.12.0
         version: 4.12.0(prisma@4.12.0)
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.0.3
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -8046,7 +8049,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.21.4)(react@18.2.0)
     optionalDependencies:
       '@next/swc-android-arm-eabi': 13.2.2
       '@next/swc-android-arm64': 13.2.2
@@ -9672,23 +9675,6 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.21.4
-      client-only: 0.0.1
-      react: 18.2.0
-    dev: false
-
-  /styled-jsx@5.1.1(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
       client-only: 0.0.1
       react: 18.2.0
     dev: false


### PR DESCRIPTION
Railway was not loading .env variables into the deployed CMS artefact. This pull request 

- adds a script to simplify the build-steps and export .env variables to a file
- add dotenv to load env variables into the KeystoneJs CMS